### PR TITLE
Fix inventory gui bugs in WidgetContainerScreen.

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,15 +1,5 @@
 # AbstractContainerScreen
 public-f net.minecraft.world.inventory.AbstractContainerMenu f_38840_ # containerId
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen f_97711_ # draggingItem
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen f_97710_ # isSplittingStack
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen f_97720_ # quickCraftingRemainder
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen f_97707_ # snapbackEnd
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen f_97715_ # snapbackItem
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen f_97712_ # snapbackStartX
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen f_97713_ # snapbackStartY
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen f_97714_ # snapbackTime
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen m_97782_(Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V # renderFloatingItem
-protected net.minecraft.client.gui.screens.inventory.AbstractContainerScreen m_97799_(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/inventory/Slot;)V # renderSlot
 # BlockBehaviour
 public net.minecraft.world.level.block.state.BlockBehaviour f_60439_ # properties
 # BlockBehaviour$Properties


### PR DESCRIPTION
I received a bug report regarding my mod, Legendary Tooltips (https://github.com/AHilyard/LegendaryTooltips/issues/54) where a component of item tooltips was misaligned, but only when viewed inside of a PackedUp backpack.
In viewing the code where the core lib renders this GUI, I found that by modifying the pose stack given to that method instead of the RenderSystem's modelView stack, certain renderers will behave differently than vanilla Minecraft behavior.

This pull request changes the rendering functionality to more closely match that of the vanilla GUI rendering behavior to help alleviate these sorts of bugs. I also added a call up to the superclass's render method--for some reason REI would not work for me without this, though I have seen that it does work with other users.  In any case, calling up to super fixes that bug as well.