### PR TITLE
Fix incorrect item interaction results foir neoforge 1.21.

### DIFF
--- a/src/main/java/com/supermartijn642/core/item/BaseBlockItem.java
+++ b/src/main/java/com/supermartijn642/core/item/BaseBlockItem.java
@@ -130,7 +130,7 @@ public class BaseBlockItem extends BlockItem {
     public static class ItemUseResult {
 
         public static ItemUseResult pass(ItemStack stack){
-            return new ItemUseResult(InteractionResult.SUCCESS, stack);
+            return new ItemUseResult(InteractionResult.PASS, stack);
         }
 
         public static ItemUseResult consume(ItemStack stack){
@@ -165,7 +165,7 @@ public class BaseBlockItem extends BlockItem {
     }
 
     public enum InteractionFeedback {
-        PASS(InteractionResult.PASS), CONSUME(InteractionResult.CONSUME), SUCCESS(InteractionResult.SUCCESS);
+        PASS(InteractionResult.PASS), CONSUME(InteractionResult.CONSUME), SUCCESS(InteractionResult.SUCCESS), FAIL(InteractionResult.FAIL), CONSUME_PARTIAL(InteractionResult.CONSUME_PARTIAL);
 
         private final InteractionResult interactionResult;
 
@@ -179,9 +179,11 @@ public class BaseBlockItem extends BlockItem {
                 case SUCCESS:
                     return SUCCESS;
                 case CONSUME:
-                case CONSUME_PARTIAL:
-                case FAIL:
                     return CONSUME;
+                case CONSUME_PARTIAL:
+                    return CONSUME_PARTIAL;
+                case FAIL:
+                    return FAIL;
                 case PASS:
                     return PASS;
             }

--- a/src/main/java/com/supermartijn642/core/item/BaseItem.java
+++ b/src/main/java/com/supermartijn642/core/item/BaseItem.java
@@ -136,7 +136,7 @@ public class BaseItem extends Item {
     protected static class ItemUseResult {
 
         public static ItemUseResult pass(ItemStack stack){
-            return new ItemUseResult(InteractionResult.SUCCESS, stack);
+            return new ItemUseResult(InteractionResult.PASS, stack);
         }
 
         public static ItemUseResult consume(ItemStack stack){


### PR DESCRIPTION
This fixes incorrect item interaction results for fail and consume_partial... The old behaviour could cause things to not interact nice with mods that place and break blocks and result in items being deleted if obstructed,
This only modifies the 1.21 branch and this issue absolutely exists on other branches as well but I don't know which of them are actively being updated.